### PR TITLE
Migration of daemons to run_daemon on the example of abacus

### DIFF
--- a/lib/rucio/daemons/abacus/account.py
+++ b/lib/rucio/daemons/abacus/account.py
@@ -49,25 +49,23 @@ def account_update(once=False, sleep_time=10):
 def run_once(heartbeat_handler, **_kwargs):
     worker_number, total_workers, logger = heartbeat_handler.live()
 
-    if True:
-        if True:
-            start = time.time()  # NOQA
-            account_rse_ids = get_updated_account_counters(total_workers=total_workers,
-                                                           worker_number=worker_number)
-            logger(logging.DEBUG, 'Index query time %f size=%d' % (time.time() - start, len(account_rse_ids)))
+    start = time.time()  # NOQA
+    account_rse_ids = get_updated_account_counters(total_workers=total_workers,
+                                                   worker_number=worker_number)
+    logger(logging.DEBUG, 'Index query time %f size=%d' % (time.time() - start, len(account_rse_ids)))
 
-            # If the list is empty, sent the worker to sleep
-            if not account_rse_ids:
-                logger(logging.INFO, 'did not get any work')
-                return
-            else:
-                for account_rse_id in account_rse_ids:
-                    worker_number, total_workers, logger = heartbeat_handler.live()
-                    if graceful_stop.is_set():
-                        break
-                    start_time = time.time()
-                    update_account_counter(account=account_rse_id[0], rse_id=account_rse_id[1])
-                    logger(logging.DEBUG, 'update of account-rse counter "%s-%s" took %f' % (account_rse_id[0], account_rse_id[1], time.time() - start_time))
+    # If the list is empty, sent the worker to sleep
+    if not account_rse_ids:
+        logger(logging.INFO, 'did not get any work')
+        return
+
+    for account_rse_id in account_rse_ids:
+        worker_number, total_workers, logger = heartbeat_handler.live()
+        if graceful_stop.is_set():
+            break
+        start_time = time.time()
+        update_account_counter(account=account_rse_id[0], rse_id=account_rse_id[1])
+        logger(logging.DEBUG, 'update of account-rse counter "%s-%s" took %f' % (account_rse_id[0], account_rse_id[1], time.time() - start_time))
 
 
 def stop(signum=None, frame=None):

--- a/lib/rucio/daemons/abacus/account.py
+++ b/lib/rucio/daemons/abacus/account.py
@@ -53,15 +53,15 @@ def account_update(once=False, sleep_time=10):
 def run_once(heartbeat_handler, **_kwargs):
     worker_number, total_workers, logger = heartbeat_handler.live()
 
-    while not graceful_stop.is_set():
-        try:
+    if True:
+        if True:
             start = time.time()  # NOQA
             account_rse_ids = get_updated_account_counters(total_workers=total_workers,
                                                            worker_number=worker_number)
             logger(logging.DEBUG, 'Index query time %f size=%d' % (time.time() - start, len(account_rse_ids)))
 
             # If the list is empty, sent the worker to sleep
-            if not account_rse_ids and not once:
+            if not account_rse_ids:
                 logger(logging.INFO, 'did not get any work')
                 daemon_sleep(start_time=start, sleep_time=sleep_time, graceful_stop=graceful_stop)
             else:
@@ -72,11 +72,6 @@ def run_once(heartbeat_handler, **_kwargs):
                     start_time = time.time()
                     update_account_counter(account=account_rse_id[0], rse_id=account_rse_id[1])
                     logger(logging.DEBUG, 'update of account-rse counter "%s-%s" took %f' % (account_rse_id[0], account_rse_id[1], time.time() - start_time))
-        except Exception:
-            logger(logging.ERROR, traceback.format_exc())
-
-        if once:
-            break
 
 
 def stop(signum=None, frame=None):

--- a/lib/rucio/daemons/abacus/account.py
+++ b/lib/rucio/daemons/abacus/account.py
@@ -63,7 +63,7 @@ def run_once(heartbeat_handler, **_kwargs):
             # If the list is empty, sent the worker to sleep
             if not account_rse_ids:
                 logger(logging.INFO, 'did not get any work')
-                daemon_sleep(start_time=start, sleep_time=sleep_time, graceful_stop=graceful_stop)
+                return
             else:
                 for account_rse_id in account_rse_ids:
                     worker_number, total_workers, logger = heartbeat_handler.live()

--- a/lib/rucio/daemons/abacus/account.py
+++ b/lib/rucio/daemons/abacus/account.py
@@ -18,18 +18,14 @@ Abacus-Account is a daemon to update Account counters.
 """
 
 import logging
-import os
-import socket
 import threading
 import time
-import traceback
 
 import rucio.db.sqla.util
 from rucio.common import exception
-from rucio.common.logging import setup_logging, formatted_logger
-from rucio.common.utils import get_thread_with_periodic_running_function, daemon_sleep
+from rucio.common.logging import setup_logging
+from rucio.common.utils import get_thread_with_periodic_running_function
 from rucio.core.account_counter import get_updated_account_counters, update_account_counter, fill_account_counter_history_table
-from rucio.core.heartbeat import live, die, sanity_check
 from rucio.daemons.common import run_daemon
 
 graceful_stop = threading.Event()

--- a/lib/rucio/daemons/abacus/account.py
+++ b/lib/rucio/daemons/abacus/account.py
@@ -30,6 +30,7 @@ from rucio.common.logging import setup_logging, formatted_logger
 from rucio.common.utils import get_thread_with_periodic_running_function, daemon_sleep
 from rucio.core.account_counter import get_updated_account_counters, update_account_counter, fill_account_counter_history_table
 from rucio.core.heartbeat import live, die, sanity_check
+from rucio.daemons.common import run_daemon
 
 graceful_stop = threading.Event()
 
@@ -38,7 +39,18 @@ def account_update(once=False, sleep_time=10):
     """
     Main loop to check and update the Account Counters.
     """
+    run_daemon(
+        once=once,
+        graceful_stop=graceful_stop,
+        executable='abacus-account',
+        logger_prefix='account_update',
+        partition_wait_time=1,
+        sleep_time=sleep_time,
+        run_once_fnc=run_once,
+    )
 
+
+def run_once(heartbeat_handler, **_kwargs):
     # Make an initial heartbeat so that all abacus-account daemons have the correct worker number on the next try
     executable = 'abacus-account'
     hostname = socket.gethostname()

--- a/lib/rucio/daemons/abacus/account.py
+++ b/lib/rucio/daemons/abacus/account.py
@@ -51,22 +51,9 @@ def account_update(once=False, sleep_time=10):
 
 
 def run_once(heartbeat_handler, **_kwargs):
-    # Make an initial heartbeat so that all abacus-account daemons have the correct worker number on the next try
-    executable = 'abacus-account'
-    hostname = socket.gethostname()
-    pid = os.getpid()
-    current_thread = threading.current_thread()
-    live(executable=executable, hostname=hostname, pid=pid, thread=current_thread)
 
     while not graceful_stop.is_set():
         try:
-            # Heartbeat
-            heartbeat = live(executable=executable, hostname=hostname, pid=pid, thread=current_thread)
-
-            prepend_str = 'account_update[%i/%i] : ' % (heartbeat['assign_thread'], heartbeat['nr_threads'])
-            logger = formatted_logger(logging.log, prepend_str + '%s')
-
-            # Select a bunch of rses for to update for this worker
             start = time.time()  # NOQA
             account_rse_ids = get_updated_account_counters(total_workers=heartbeat['nr_threads'],
                                                            worker_number=heartbeat['assign_thread'])
@@ -89,10 +76,6 @@ def run_once(heartbeat_handler, **_kwargs):
         if once:
             break
 
-    logging.info('account_update: graceful stop requested')
-    die(executable=executable, hostname=hostname, pid=pid, thread=current_thread)
-    logging.info('account_update: graceful stop done')
-
 
 def stop(signum=None, frame=None):
     """
@@ -110,10 +93,6 @@ def run(once=False, threads=1, fill_history_table=False, sleep_time=10):
 
     if rucio.db.sqla.util.is_old_db():
         raise exception.DatabaseException('Database was not updated, daemon won\'t start')
-
-    executable = 'abacus-account'
-    hostname = socket.gethostname()
-    sanity_check(executable=executable, hostname=hostname)
 
     if once:
         logging.info('main: executing one iteration only')

--- a/lib/rucio/daemons/abacus/account.py
+++ b/lib/rucio/daemons/abacus/account.py
@@ -51,12 +51,13 @@ def account_update(once=False, sleep_time=10):
 
 
 def run_once(heartbeat_handler, **_kwargs):
+    worker_number, total_workers, logger = heartbeat_handler.live()
 
     while not graceful_stop.is_set():
         try:
             start = time.time()  # NOQA
-            account_rse_ids = get_updated_account_counters(total_workers=heartbeat['nr_threads'],
-                                                           worker_number=heartbeat['assign_thread'])
+            account_rse_ids = get_updated_account_counters(total_workers=total_workers,
+                                                           worker_number=worker_number)
             logger(logging.DEBUG, 'Index query time %f size=%d' % (time.time() - start, len(account_rse_ids)))
 
             # If the list is empty, sent the worker to sleep
@@ -65,6 +66,7 @@ def run_once(heartbeat_handler, **_kwargs):
                 daemon_sleep(start_time=start, sleep_time=sleep_time, graceful_stop=graceful_stop)
             else:
                 for account_rse_id in account_rse_ids:
+                    worker_number, total_workers, logger = heartbeat_handler.live()
                     if graceful_stop.is_set():
                         break
                     start_time = time.time()

--- a/lib/rucio/daemons/abacus/collection_replica.py
+++ b/lib/rucio/daemons/abacus/collection_replica.py
@@ -18,17 +18,12 @@ Abacus-Collection-Replica is a daemon to update collection replica.
 """
 import functools
 import logging
-import os
-import socket
 import threading
 import time
-import traceback
 
 import rucio.db.sqla.util
 from rucio.common import exception
-from rucio.common.logging import setup_logging, formatted_logger
-from rucio.common.utils import daemon_sleep
-from rucio.core.heartbeat import live, die, sanity_check
+from rucio.common.logging import setup_logging
 from rucio.core.replica import get_cleaned_updated_collection_replicas, update_collection_replica
 from rucio.daemons.common import run_daemon
 

--- a/lib/rucio/daemons/abacus/collection_replica.py
+++ b/lib/rucio/daemons/abacus/collection_replica.py
@@ -67,7 +67,8 @@ def run_once(heartbeat_handler, limit, **_kwargs):
             # If the list is empty, sent the worker to sleep
             if not replicas:
                 logger(logging.INFO, 'did not get any work')
-                daemon_sleep(start_time=start, sleep_time=sleep_time, graceful_stop=graceful_stop)
+                must_sleep = True
+                return must_sleep
             else:
                 for replica in replicas:
                     worker_number, total_workers, logger = heartbeat_handler.live()
@@ -76,8 +77,10 @@ def run_once(heartbeat_handler, limit, **_kwargs):
                     start_time = time.time()
                     update_collection_replica(replica)
                     logger(logging.DEBUG, 'update of collection replica "%s" took %f' % (replica['id'], time.time() - start_time))
+                must_sleep = False
                 if limit and len(replicas) < limit:
-                    daemon_sleep(start_time=start, sleep_time=sleep_time, graceful_stop=graceful_stop)
+                    must_sleep = True
+                return must_sleep
 
 
 def stop(signum=None, frame=None):

--- a/lib/rucio/daemons/abacus/collection_replica.py
+++ b/lib/rucio/daemons/abacus/collection_replica.py
@@ -16,7 +16,7 @@
 """
 Abacus-Collection-Replica is a daemon to update collection replica.
 """
-
+import functools
 import logging
 import os
 import socket
@@ -30,6 +30,7 @@ from rucio.common.logging import setup_logging, formatted_logger
 from rucio.common.utils import daemon_sleep
 from rucio.core.heartbeat import live, die, sanity_check
 from rucio.core.replica import get_cleaned_updated_collection_replicas, update_collection_replica
+from rucio.daemons.common import run_daemon
 
 graceful_stop = threading.Event()
 
@@ -38,7 +39,21 @@ def collection_replica_update(once=False, limit=1000, sleep_time=10):
     """
     Main loop to check and update the collection replicas.
     """
+    run_daemon(
+        once=once,
+        graceful_stop=graceful_stop,
+        executable='abacus-collection-replica',
+        logger_prefix='collection_replica_update',
+        partition_wait_time=1,
+        sleep_time=sleep_time,
+        run_once_fnc=functools.partial(
+            run_once,
+            limit=limit,
+        ),
+    )
 
+
+def run_once(heartbeat_handler, limit, **_kwargs):
     # Make an initial heartbeat so that all abacus-collection-replica daemons have the correct worker number on the next try
     executable = 'abacus-collection-replica'
     hostname = socket.gethostname()

--- a/lib/rucio/daemons/abacus/collection_replica.py
+++ b/lib/rucio/daemons/abacus/collection_replica.py
@@ -54,21 +54,8 @@ def collection_replica_update(once=False, limit=1000, sleep_time=10):
 
 
 def run_once(heartbeat_handler, limit, **_kwargs):
-    # Make an initial heartbeat so that all abacus-collection-replica daemons have the correct worker number on the next try
-    executable = 'abacus-collection-replica'
-    hostname = socket.gethostname()
-    pid = os.getpid()
-    current_thread = threading.current_thread()
-    live(executable=executable, hostname=hostname, pid=pid, thread=current_thread)
-
     while not graceful_stop.is_set():
         try:
-            # Heartbeat
-            heartbeat = live(executable=executable, hostname=hostname, pid=pid, thread=current_thread)
-
-            prepend_str = 'collection_replica_update[%i/%i] : ' % (heartbeat['assign_thread'], heartbeat['nr_threads'])
-            logger = formatted_logger(logging.log, prepend_str + '%s')
-
             # Select a bunch of collection replicas for to update for this worker
             start = time.time()  # NOQA
             replicas = get_cleaned_updated_collection_replicas(total_workers=heartbeat['nr_threads'] - 1,
@@ -95,10 +82,6 @@ def run_once(heartbeat_handler, limit, **_kwargs):
         if once:
             break
 
-    logging.info('collection_replica_update: graceful stop requested')
-    die(executable=executable, hostname=hostname, pid=pid, thread=current_thread)
-    logging.info('collection_replica_update: graceful stop done')
-
 
 def stop(signum=None, frame=None):
     """
@@ -116,10 +99,6 @@ def run(once=False, threads=1, sleep_time=10, limit=1000):
 
     if rucio.db.sqla.util.is_old_db():
         raise exception.DatabaseException('Database was not updated, daemon won\'t start')
-
-    executable = 'abacus-collection-replica'
-    hostname = socket.gethostname()
-    sanity_check(executable=executable, hostname=hostname)
 
     if once:
         logging.info('main: executing one iteration only')

--- a/lib/rucio/daemons/abacus/collection_replica.py
+++ b/lib/rucio/daemons/abacus/collection_replica.py
@@ -55,8 +55,8 @@ def collection_replica_update(once=False, limit=1000, sleep_time=10):
 
 def run_once(heartbeat_handler, limit, **_kwargs):
     worker_number, total_workers, logger = heartbeat_handler.live()
-    while not graceful_stop.is_set():
-        try:
+    if True:
+        if True:
             # Select a bunch of collection replicas for to update for this worker
             start = time.time()  # NOQA
             replicas = get_cleaned_updated_collection_replicas(total_workers=total_workers - 1,
@@ -65,7 +65,7 @@ def run_once(heartbeat_handler, limit, **_kwargs):
 
             logger(logging.DEBUG, 'Index query time %f size=%d' % (time.time() - start, len(replicas)))
             # If the list is empty, sent the worker to sleep
-            if not replicas and not once:
+            if not replicas:
                 logger(logging.INFO, 'did not get any work')
                 daemon_sleep(start_time=start, sleep_time=sleep_time, graceful_stop=graceful_stop)
             else:
@@ -76,13 +76,8 @@ def run_once(heartbeat_handler, limit, **_kwargs):
                     start_time = time.time()
                     update_collection_replica(replica)
                     logger(logging.DEBUG, 'update of collection replica "%s" took %f' % (replica['id'], time.time() - start_time))
-                if limit and len(replicas) < limit and not once:
+                if limit and len(replicas) < limit:
                     daemon_sleep(start_time=start, sleep_time=sleep_time, graceful_stop=graceful_stop)
-
-        except Exception:
-            logger(logging.ERROR, traceback.format_exc())
-        if once:
-            break
 
 
 def stop(signum=None, frame=None):

--- a/lib/rucio/daemons/abacus/collection_replica.py
+++ b/lib/rucio/daemons/abacus/collection_replica.py
@@ -54,12 +54,13 @@ def collection_replica_update(once=False, limit=1000, sleep_time=10):
 
 
 def run_once(heartbeat_handler, limit, **_kwargs):
+    worker_number, total_workers, logger = heartbeat_handler.live()
     while not graceful_stop.is_set():
         try:
             # Select a bunch of collection replicas for to update for this worker
             start = time.time()  # NOQA
-            replicas = get_cleaned_updated_collection_replicas(total_workers=heartbeat['nr_threads'] - 1,
-                                                               worker_number=heartbeat['assign_thread'],
+            replicas = get_cleaned_updated_collection_replicas(total_workers=total_workers - 1,
+                                                               worker_number=worker_number,
                                                                limit=limit)
 
             logger(logging.DEBUG, 'Index query time %f size=%d' % (time.time() - start, len(replicas)))
@@ -69,6 +70,7 @@ def run_once(heartbeat_handler, limit, **_kwargs):
                 daemon_sleep(start_time=start, sleep_time=sleep_time, graceful_stop=graceful_stop)
             else:
                 for replica in replicas:
+                    worker_number, total_workers, logger = heartbeat_handler.live()
                     if graceful_stop.is_set():
                         break
                     start_time = time.time()

--- a/lib/rucio/daemons/abacus/rse.py
+++ b/lib/rucio/daemons/abacus/rse.py
@@ -49,26 +49,24 @@ def rse_update(once=False, sleep_time=10):
 def run_once(heartbeat_handler, **_kwargs):
     worker_number, total_workers, logger = heartbeat_handler.live()
 
-    if True:
-        if True:
-            # Select a bunch of rses for to update for this worker
-            start = time.time()  # NOQA
-            rse_ids = get_updated_rse_counters(total_workers=total_workers,
-                                               worker_number=worker_number)
-            logger(logging.DEBUG, 'Index query time %f size=%d' % (time.time() - start, len(rse_ids)))
+    # Select a bunch of rses for to update for this worker
+    start = time.time()  # NOQA
+    rse_ids = get_updated_rse_counters(total_workers=total_workers,
+                                       worker_number=worker_number)
+    logger(logging.DEBUG, 'Index query time %f size=%d' % (time.time() - start, len(rse_ids)))
 
-            # If the list is empty, sent the worker to sleep
-            if not rse_ids:
-                logger(logging.INFO, 'did not get any work')
-                return
-            else:
-                for rse_id in rse_ids:
-                    worker_number, total_workers, logger = heartbeat_handler.live()
-                    if graceful_stop.is_set():
-                        break
-                    start_time = time.time()
-                    update_rse_counter(rse_id=rse_id)
-                    logger(logging.DEBUG, 'update of rse "%s" took %f' % (rse_id, time.time() - start_time))
+    # If the list is empty, sent the worker to sleep
+    if not rse_ids:
+        logger(logging.INFO, 'did not get any work')
+        return
+
+    for rse_id in rse_ids:
+        worker_number, total_workers, logger = heartbeat_handler.live()
+        if graceful_stop.is_set():
+            break
+        start_time = time.time()
+        update_rse_counter(rse_id=rse_id)
+        logger(logging.DEBUG, 'update of rse "%s" took %f' % (rse_id, time.time() - start_time))
 
 
 def stop(signum=None, frame=None):

--- a/lib/rucio/daemons/abacus/rse.py
+++ b/lib/rucio/daemons/abacus/rse.py
@@ -53,8 +53,8 @@ def rse_update(once=False, sleep_time=10):
 def run_once(heartbeat_handler, **_kwargs):
     worker_number, total_workers, logger = heartbeat_handler.live()
 
-    while not graceful_stop.is_set():
-        try:
+    if True:
+        if True:
             # Select a bunch of rses for to update for this worker
             start = time.time()  # NOQA
             rse_ids = get_updated_rse_counters(total_workers=total_workers,
@@ -62,7 +62,7 @@ def run_once(heartbeat_handler, **_kwargs):
             logger(logging.DEBUG, 'Index query time %f size=%d' % (time.time() - start, len(rse_ids)))
 
             # If the list is empty, sent the worker to sleep
-            if not rse_ids and not once:
+            if not rse_ids:
                 logger(logging.INFO, 'did not get any work')
                 daemon_sleep(start_time=start, sleep_time=sleep_time, graceful_stop=graceful_stop)
             else:
@@ -73,10 +73,6 @@ def run_once(heartbeat_handler, **_kwargs):
                     start_time = time.time()
                     update_rse_counter(rse_id=rse_id)
                     logger(logging.DEBUG, 'update of rse "%s" took %f' % (rse_id, time.time() - start_time))
-        except Exception:
-            logger(logging.ERROR, traceback.format_exc())
-        if once:
-            break
 
 
 def stop(signum=None, frame=None):

--- a/lib/rucio/daemons/abacus/rse.py
+++ b/lib/rucio/daemons/abacus/rse.py
@@ -30,6 +30,7 @@ from rucio.common.logging import setup_logging, formatted_logger
 from rucio.common.utils import get_thread_with_periodic_running_function, daemon_sleep
 from rucio.core.heartbeat import live, die, sanity_check
 from rucio.core.rse_counter import get_updated_rse_counters, update_rse_counter, fill_rse_counter_history_table
+from rucio.daemons.common import run_daemon
 
 graceful_stop = threading.Event()
 
@@ -38,7 +39,18 @@ def rse_update(once=False, sleep_time=10):
     """
     Main loop to check and update the RSE Counters.
     """
+    run_daemon(
+        once=once,
+        graceful_stop=graceful_stop,
+        executable='abacus-rse',
+        logger_prefix='rse_update',
+        partition_wait_time=1,
+        sleep_time=sleep_time,
+        run_once_fnc=run_once,
+    )
 
+
+def run_once(heartbeat_handler, **_kwargs):
     # Make an initial heartbeat so that all abacus-rse daemons have the correct worker number on the next try
     executable = 'abacus-rse'
     hostname = socket.gethostname()

--- a/lib/rucio/daemons/abacus/rse.py
+++ b/lib/rucio/daemons/abacus/rse.py
@@ -64,7 +64,7 @@ def run_once(heartbeat_handler, **_kwargs):
             # If the list is empty, sent the worker to sleep
             if not rse_ids:
                 logger(logging.INFO, 'did not get any work')
-                daemon_sleep(start_time=start, sleep_time=sleep_time, graceful_stop=graceful_stop)
+                return
             else:
                 for rse_id in rse_ids:
                     worker_number, total_workers, logger = heartbeat_handler.live()

--- a/lib/rucio/daemons/abacus/rse.py
+++ b/lib/rucio/daemons/abacus/rse.py
@@ -51,21 +51,9 @@ def rse_update(once=False, sleep_time=10):
 
 
 def run_once(heartbeat_handler, **_kwargs):
-    # Make an initial heartbeat so that all abacus-rse daemons have the correct worker number on the next try
-    executable = 'abacus-rse'
-    hostname = socket.gethostname()
-    pid = os.getpid()
-    current_thread = threading.current_thread()
-    live(executable=executable, hostname=hostname, pid=pid, thread=current_thread)
 
     while not graceful_stop.is_set():
         try:
-            # Heartbeat
-            heartbeat = live(executable=executable, hostname=hostname, pid=pid, thread=current_thread)
-
-            prepend_str = 'rse_update[%i/%i] : ' % (heartbeat['assign_thread'], heartbeat['nr_threads'])
-            logger = formatted_logger(logging.log, prepend_str + '%s')
-
             # Select a bunch of rses for to update for this worker
             start = time.time()  # NOQA
             rse_ids = get_updated_rse_counters(total_workers=heartbeat['nr_threads'],
@@ -88,10 +76,6 @@ def run_once(heartbeat_handler, **_kwargs):
         if once:
             break
 
-    logging.info('rse_update: graceful stop requested')
-    die(executable=executable, hostname=hostname, pid=pid, thread=current_thread)
-    logging.info('rse_update: graceful stop done')
-
 
 def stop(signum=None, frame=None):
     """
@@ -109,10 +93,6 @@ def run(once=False, threads=1, fill_history_table=False, sleep_time=10):
 
     if rucio.db.sqla.util.is_old_db():
         raise exception.DatabaseException('Database was not updated, daemon won\'t start')
-
-    executable = 'abacus-rse'
-    hostname = socket.gethostname()
-    sanity_check(executable=executable, hostname=hostname)
 
     if once:
         logging.info('main: executing one iteration only')

--- a/lib/rucio/daemons/abacus/rse.py
+++ b/lib/rucio/daemons/abacus/rse.py
@@ -18,17 +18,13 @@ Abacus-RSE is a daemon to update RSE counters.
 """
 
 import logging
-import os
-import socket
 import threading
 import time
-import traceback
 
 import rucio.db.sqla.util
 from rucio.common import exception
-from rucio.common.logging import setup_logging, formatted_logger
-from rucio.common.utils import get_thread_with_periodic_running_function, daemon_sleep
-from rucio.core.heartbeat import live, die, sanity_check
+from rucio.common.logging import setup_logging
+from rucio.common.utils import get_thread_with_periodic_running_function
 from rucio.core.rse_counter import get_updated_rse_counters, update_rse_counter, fill_rse_counter_history_table
 from rucio.daemons.common import run_daemon
 

--- a/lib/rucio/daemons/abacus/rse.py
+++ b/lib/rucio/daemons/abacus/rse.py
@@ -51,13 +51,14 @@ def rse_update(once=False, sleep_time=10):
 
 
 def run_once(heartbeat_handler, **_kwargs):
+    worker_number, total_workers, logger = heartbeat_handler.live()
 
     while not graceful_stop.is_set():
         try:
             # Select a bunch of rses for to update for this worker
             start = time.time()  # NOQA
-            rse_ids = get_updated_rse_counters(total_workers=heartbeat['nr_threads'],
-                                               worker_number=heartbeat['assign_thread'])
+            rse_ids = get_updated_rse_counters(total_workers=total_workers,
+                                               worker_number=worker_number)
             logger(logging.DEBUG, 'Index query time %f size=%d' % (time.time() - start, len(rse_ids)))
 
             # If the list is empty, sent the worker to sleep
@@ -66,6 +67,7 @@ def run_once(heartbeat_handler, **_kwargs):
                 daemon_sleep(start_time=start, sleep_time=sleep_time, graceful_stop=graceful_stop)
             else:
                 for rse_id in rse_ids:
+                    worker_number, total_workers, logger = heartbeat_handler.live()
                     if graceful_stop.is_set():
                         break
                     start_time = time.time()


### PR DESCRIPTION
To reduce the amount of boilerplate code in daemons, we created two helpers:
- the [HearbeatHandler](https://github.com/rcarpa/rucio/blob/b77058f25d4449872eb80beb05da8a9f0b6af135/lib/rucio/daemons/common.py#L30) class. It can be used as a context manager and serves as a higher-level primitive for creating, maintaining, and cleaning-up hearbeats. It also has some logic for throttling how frequently the hearbeats are actually updated in the database. 
- the [run_daemon](https://github.com/rcarpa/rucio/blob/b77058f25d4449872eb80beb05da8a9f0b6af135/lib/rucio/daemons/common.py#L93) function which contains the infinite daemon loop. It instantiates a HeartbeatHandler; calls a provided callback function in each iteration; Sleeps (if needed) between iterations; 

The next step is to migrate existing daemons to using these primitives instead of re-implementing the same behavior over-and-over again. This PR serves as an example of how to remove boilerplate from existing daemons. 

*Step 1*: Refer to the "step1" commit in this PR for an example. As already mentioned, run_daemon implements the daemon loop. It expects multiple arguments which are related to handling the loop (how much time to sleep between iteration; how much to wait for partition re-balancing at startup; etc..) and also a callback function, which is expected to perform the actual work. This callback function is expected to take exactly two keyword arguments: `hearbeat_handler` and `activity`. The first step in the migration is to move the existing daemon code into a run_once function. If the daemon code requires additional arguments, use `functools.partial` to set them, as it is done in `collection_replica.py`. Because the abacus daemons don't work per activity, I use run_daemons without passing any activity and I collect/ignore the `activity=` keyword argument in `**_kwargs`. Check the [poller](https://github.com/rcarpa/rucio/blob/b10d485fd31555d17ac1e4143380a3b09ab83a4a/lib/rucio/daemons/conveyor/poller.py#L137) for an example of daemon working on per-activity basis.

*Step 2*: The `hearbeat_handler`, passed by the `run_daemon` to the `run_once` function allows to remove most boilerplate code related to logger decoration. It also takes care of sanity check and cleanup of hearbeats. Remove the un-needed code. 

*Step 3*: use `hearbeat_handler.live()` to retrieve the decorated logger and to update hearbeats whenever needed. `run_daemon` has shorter implicit `older_than`, but this is not a problem, because calling `live()` doesn't necessarily result into a database row update. Just call `live()` more frequently. For example, inside the loop which works on each element. 

*Step 4*: `run_daemon` implements the infinite `while True` loop; the `once` logic; and the catch-all `try...except` block. Remove them. To have better "diffs" in git, I choose to substitute them with "if True:" for now (will be removed later).

*Step 5*: `run_daemon` implements the logic to sleep between daemon iterations. If the run_once function returns `None`, it will automatically  sleep for `sleep_time`. Howether, the run_once function can decide to explicitly tell the calling context if sleep is desired by returning a boolean. If "True" is returned, `run_daemon` will sleep, else it will re-iterate immediately without sleeping. See the commit for examples of both behaviors. 

*Step 6 and 7*: quite obvious: remove the un-needed imports and de-indent the code if needed.
